### PR TITLE
fix examples for usage with fimex 1.x (no set_filetype)

### DIFF
--- a/modules/F90/fimex2d_example.cdl
+++ b/modules/F90/fimex2d_example.cdl
@@ -1,7 +1,7 @@
 netcdf fimex2d_example {
 dimensions:
-	y = 949 ;
-	x = 739 ;
+	y = 1069 ;
+	x = 949 ;
 variables:
     float air_temperature_2m(y, x) ;
         air_temperature_2m:units = "1" ;

--- a/modules/F90/fortran_test.f90
+++ b/modules/F90/fortran_test.f90
@@ -1,8 +1,7 @@
 !> @example fortran_test.f90
 !! Example on using the fimex interface
 PROGRAM fortran_test
-  USE Fimex, ONLY                   : FimexIO, AXIS_GeoX, AXIS_GeoY, AXIS_Lon, AXIS_Lat,INTERPOL_BILINEAR,&
-                                      FILETYPE_RW
+  USE Fimex, ONLY                   : FimexIO, AXIS_GeoX, AXIS_GeoY, AXIS_Lon, AXIS_Lat,INTERPOL_BILINEAR
   IMPLICIT NONE
   TYPE(FimexIO)                   :: fio, finter, finter2, frw
   INTEGER                         :: ierr,i
@@ -232,7 +231,7 @@ PROGRAM fortran_test
     ENDIF
     ! write the data to testOut.nc
     ! Open file
-    ierr=frw%open("testOut.nc","","netcdf")
+    ierr=frw%open("testOut.nc","","netcdf+rw")
     IF ( ierr /= 0 ) CALL error("Can't make rw-object with file: testOut.nc")
     ndims=frw%get_dimensions("pressure")
     IF ( ndims <= 0 ) CALL error("Can't make slicebuilder for pressure in testOut.nc")

--- a/modules/F90/run_example2d.sh
+++ b/modules/F90/run_example2d.sh
@@ -3,16 +3,22 @@
 set -x
 fimex=/usr
 
+testfile=/lustre/storeB/project/metproduction/products/meps/meps_det_2_5km_20200310T12Z.ncml
+
 ncgen -b fimex2d_example.cdl -o fimex2d_example.nc4
-fimex --input.file=/opdata/arome2_5_main/AROME_MetCoOp_00_fp.nc --output.file=fimex2d_example_all.nc4 --extract.selectVariables=x --extract.selectVariables=y --extract.selectVariables=longitude --extract.selectVariables=latitude
+fimex --input.file=${testfile} --output.file=fimex2d_example_all.nc4 --extract.selectVariables=air_temperature_2m
 
-gfortran -O3 -Wall -Werror fimex2d_example.F90 -o fimex2d_example -I$fimex/include -I. -L$fimex/lib/ -lfimexf -lfimex -Wall -Werror -Wl,-rpath=$fimex/lib/ || exit 1
+# use 
+# pkg-config --cflags fimex
+# pkg-config --libs fimex
+#   and guess -lfimexf version
+#gfortran -O3 -Wall -Werror fimex2d_example.F90 -o fimex2d_example `pkg-config --cflags fimex` `pkg-config --libs fimex` -Wall -Werror -Wl,-rpath=$fimex/lib/ || exit 1
 
-./fimex2d_example /opdata/arome2_5_main/AROME_MetCoOp_00_fp.nc fimex2d_example.nc4 netcdf || exit 1
+./fimex2d_example ${testfile} fimex2d_example.nc4 ncml || exit 1
 
 vars="air_temperature_2m"
 for var in $vars; do
   ncks -A -v $var fimex2d_example.nc4 fimex2d_example_all.nc4
 done
 
-ncview2 fimex2d_example_all.nc4
+ncview fimex2d_example_all.nc4


### PR DESCRIPTION
Fortran-examples didn't compile any longer with fimex-versions > 1.x. Fixed.