### PR TITLE
exposing projection in f90 as proj4

### DIFF
--- a/modules/F90/testFortran.F90
+++ b/modules/F90/testFortran.F90
@@ -57,6 +57,7 @@ PROGRAM fortran_test
   ndims=fio%get_dimensions(varName)
   IF ( ndims .ne. 3 ) CALL error("Unexpected dimension count")
   WRITE(0,*) "get_dimensions: ", ndims
+  WRITE(0,*) "projection: ", fio%get_proj4()
 
   if ("x"    .ne. fio%get_dimname(1)) CALL error("Unexpected 'x' dimension name")
   if ("y"    .ne. fio%get_dimname(2)) CALL error("Unexpected 'y' dimension name")


### PR DESCRIPTION
I need access to the projection information to the projection information to setup the projection library in my downstream f90-application (SNAP) processing the data in the original projection. I don't want to interpolate the original data to another projection, because it will reduce the data's quality.