### PR TITLE
extending xsd with omitEmptyFields option

### DIFF
--- a/share/etc/cdmGribWriterConfig.xml
+++ b/share/etc/cdmGribWriterConfig.xml
@@ -4,6 +4,11 @@
 <!--                        xsi:noNamespaceSchemaLocation="cdmGribWriterConfig.xsd"> -->
 <!-- select a specialized grib-template instead of using the default grib_api file -->
 <!-- <template_file name="/disk1/Fimex/conc_Am-241.ID_328.grib" /> -->
+<!-- allow writing of fields with only missing-values, default true
+<processing_options>
+    <omitEmptyFields>false</omitEmptyFields>
+</processing_options>
+-->
 <!-- output-file configuration, default-type: overwrite -->
 <!-- <output_file type="append" />  -->
 <global_attributes>

--- a/share/etc/cdmGribWriterConfig.xsd
+++ b/share/etc/cdmGribWriterConfig.xsd
@@ -5,6 +5,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="template_file" minOccurs="0" maxOccurs="1" />
+        <xs:element ref="processing_options" minOccurs="0" maxOccurs="1" />
         <xs:element ref="output_file" minOccurs="0" maxOccurs="1" />
         <xs:element ref="global_attributes" minOccurs="1" maxOccurs="1"/>
         <xs:element ref="axes" minOccurs="1" maxOccurs="1"/>
@@ -15,6 +16,13 @@
   <xs:element name="template_file">
     <xs:complexType>
       <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="processing_options">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="omitEmptyFields" type="xs:boolean" />
+      </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="output_file">


### PR DESCRIPTION
Added some example code to cdmGribWriterConfig.xml using omitEmptyFields option, and added the option to the xsd-schema.