### PR TITLE
Update fimex.f90

### DIFF
--- a/modules/F90/fimex.f90
+++ b/modules/F90/fimex.f90
@@ -24,7 +24,8 @@
 MODULE Fimex
   USE iso_c_binding, ONLY : C_PTR, C_NULL_PTR
   IMPLICIT NONE
-
+  PUBLIC
+  
   !> Axis-definitions
   !! These are the same definitions as in CoordinateAxis::AxisType
   ENUM, BIND(C)


### PR DESCRIPTION
Export symbols explicitly to public, in case compiler settings are set to default-private.