### PR TITLE
Add vertical model-levels for hybrid to grib-output

### DIFF
--- a/src/io/grib/GribApiCDMWriter_Impl1.cc
+++ b/src/io/grib/GribApiCDMWriter_Impl1.cc
@@ -350,9 +350,9 @@ void GribApiCDMWriter_Impl1::setProjection(const std::string& varName)
     }
 }
 
-void GribApiCDMWriter_Impl1::setLevel(const std::string& varName, double levelValue)
+void GribApiCDMWriter_Impl1::setLevel(const std::string& varName, double levelValue, size_t levelPos)
 {
-    LOG4FIMEX(logger, Logger::DEBUG, "setLevel(" << varName << ", " << levelValue << ")");
+    LOG4FIMEX(logger, Logger::DEBUG, "setLevel(" << varName << ", " << levelValue << ", " << levelPos << ")");
     // check for level/parameter dependencies
     const CDM& cdm = cdmReader->getCDM();
     std::string verticalAxis = cdm.getVerticalAxis(varName);

--- a/src/io/grib/GribApiCDMWriter_Impl1.h
+++ b/src/io/grib/GribApiCDMWriter_Impl1.h
@@ -40,7 +40,7 @@ public:
 
     virtual void setParameter(const std::string& varName, double levelValue);
     virtual void setProjection(const std::string& varName);
-    virtual void setLevel(const std::string& varName, double levelValue);
+    virtual void setLevel(const std::string& varName, double levelValue, size_t levelPos);
     virtual DataPtr handleTypeScaleAndMissingData(const std::string& varName, double levelValue, DataPtr inData);
 };
 

--- a/src/io/grib/GribApiCDMWriter_Impl2.h
+++ b/src/io/grib/GribApiCDMWriter_Impl2.h
@@ -40,7 +40,7 @@ public:
 
     virtual void setParameter(const std::string& varName, double levelValue);
     virtual void setProjection(const std::string& varName);
-    virtual void setLevel(const std::string& varName, double levelValue);
+    virtual void setLevel(const std::string& varName, double levelValue, size_t levelPos);
     virtual DataPtr handleTypeScaleAndMissingData(const std::string& varName, double levelValue, DataPtr inData);
 };
 

--- a/src/io/grib/GribApiCDMWriter_ImplAbstract.cc
+++ b/src/io/grib/GribApiCDMWriter_ImplAbstract.cc
@@ -310,7 +310,7 @@ void GribApiCDMWriter_ImplAbstract::run()
                             double levelVal = levels.at(levelPos);
                             try {
                                 // level and var are dependent due to splitting possibilities
-                                setLevel(*var, levelVal);
+                                setLevel(*var, levelVal, levelPos);
                                 setParameter(*var, levelVal);
                                 DataPtr data = cdmReader->getDataSlice(*var, sb);
                                 if (data->size() != 0) {

--- a/src/io/grib/GribApiCDMWriter_ImplAbstract.h
+++ b/src/io/grib/GribApiCDMWriter_ImplAbstract.h
@@ -78,7 +78,7 @@ protected:
     virtual void setProjection(const std::string& varName) = 0;
     virtual void setParameter(const std::string& varName, double levelValue) = 0;
     virtual void setTime(const std::string& varName, const FimexTime& rTime, const FimexTime& vTime, const std::string& stepUnit);
-    virtual void setLevel(const std::string& varName, double levelValue) = 0;
+    virtual void setLevel(const std::string& varName, double levelValue, size_t levelPos) = 0;
     /**
      * get the levels from the cdm scaled to values used in grib (units/scale-factor)
      * assign at least 1 level, give it a default value if none is found in the cdm


### PR DESCRIPTION
This PR adds vertical "pv" levels of type "extraHalvLevels" to grib2 files with vertical level-type 105.
It solves #40 at least for the most needed cases.