### PR TITLE
Adding Geopotential-Height as processor

### DIFF
--- a/cmake-variants.yaml
+++ b/cmake-variants.yaml
@@ -1,0 +1,47 @@
+buildType:
+  default: debug
+  choices:
+    debug:
+      short: Debug
+      long: Emit debug information
+      buildType: Debug
+    release:
+      short: Release
+      long: Optimize generated code
+      buildType: Release
+
+linkage:
+  default: static
+  choices:
+    static:
+      short: Static
+      long: Create static libraries
+      linkage: static
+    shared:
+      short: Shared
+      long: Create shared libraries/DLLs
+      linkage: shared
+
+fortran:
+  default: yes
+  choices:
+    yes:
+      short: Fortran
+      settings:
+        ENABLE_FORTRAN: yes
+    no:
+      short: NoFortran
+      settings:
+        ENABLE_FORTRAN: no
+
+python:
+  default: yes
+  choices:
+    yes:
+      short: Python
+      settings:
+        ENABLE_PYTHON: yes
+    no:
+      short: NoPython
+      settings:
+        ENABLE_PYTHON: no

--- a/cmake-variants.yaml
+++ b/cmake-variants.yaml
@@ -45,3 +45,15 @@ python:
       short: NoPython
       settings:
         ENABLE_PYTHON: no
+
+log4cpp:
+  default: yes
+  choices:
+    yes:
+      short: Log4cpp
+      settings:
+        ENABLE_LOG4CPP: yes
+    no:
+      short: NoLog4cpp
+      settings:
+        ENABLE_LOG4CPP: no

--- a/include/fimex/CDMProcessor.h
+++ b/include/fimex/CDMProcessor.h
@@ -45,6 +45,13 @@ public:
     CDMProcessor(CDMReader_p dataReader);
     virtual ~CDMProcessor();
     /**
+     * add geopotential to this CDM, on model-levels using
+     * t_v = t * (1. + 0.609133 * q)
+     * and integrate from bottom up
+     * delta_z = R*T_v[l]/g0*np.log(p_half[l]/p_half[l-1])
+     */
+    void addGeopotentialHeightInModelLayers();
+    /**
      * add vertical velocity to this CDM, using continuity equation on model-levels
      */
     void addVerticalVelocity();

--- a/src/binSrc/fimex.cc
+++ b/src/binSrc/fimex.cc
@@ -122,6 +122,8 @@ const po::option op_process_rotateVector_all = po::option("process.rotateVector.
         "rotate all known vectors (e.g. standard_name) to given direction").set_narg(0);
 const po::option op_process_addVerticalVelocity = po::option("process.addVerticalVelocity",
         "calculate upward_air_velocity_ml");
+const po::option op_process_addGeopotentialHeightML = po::option("process.addGeopotentialHeightML",
+        "calculate geopotential_height_ml");
 const po::option op_process_printNcML = po::option("process.printNcML",
         "print NcML description of process").set_implicit_value("-");
 const po::option op_process_printCS = po::option("process.printCS", "print CoordinateSystems of process").set_narg(0);
@@ -421,8 +423,8 @@ int getInterpolationMethod(const po::value_set& vm, const po::option& opt)
 CDMReader_p getCDMProcessor(const po::value_set& vm, CDMReader_p dataReader)
 {
     if (!(vm.is_set(op_process_accumulateVariable) || vm.is_set(op_process_deaccumulateVariable) || vm.is_set(op_process_rotateVector_direction) ||
-          vm.is_set(op_process_addVerticalVelocity))) {
-        LOG4FIMEX(logger, Logger::DEBUG, "process.[de]accumulateVariable or rotateVector.direction or addVerticalVelocity not found, no process used");
+          vm.is_set(op_process_addVerticalVelocity) || vm.is_set(op_process_addGeopotentialHeightML))) {
+        LOG4FIMEX(logger, Logger::DEBUG, "process.[de]accumulateVariable or rotateVector.direction or addVerticalVelocity or addGeopotentialHeightML not found, no process used");
         return dataReader;
     }
     std::shared_ptr<CDMProcessor> processor(new CDMProcessor(dataReader));
@@ -466,6 +468,9 @@ CDMReader_p getCDMProcessor(const po::value_set& vm, CDMReader_p dataReader)
     }
     if (vm.is_set(op_process_addVerticalVelocity)) {
         processor->addVerticalVelocity();
+    }
+    if (vm.is_set(op_process_addGeopotentialHeightML)) {
+        processor->addGeopotentialHeightInModelLayers();
     }
     return processor;
 }
@@ -921,6 +926,7 @@ int run(int argc, char* args[])
         << op_process_rotateVector_stdNameY
         << op_process_rotateVector_all
         << op_process_addVerticalVelocity
+        << op_process_addGeopotentialHeightML
         << op_process_printNcML
         << op_process_printCS
         << op_process_printSize

--- a/src/coordSys/verticalTransform/HybridSigmaApToPressureConverter.cc
+++ b/src/coordSys/verticalTransform/HybridSigmaApToPressureConverter.cc
@@ -89,10 +89,10 @@ DataPtr HybridSigmaApToPressureConverter::getDataSlice(const SliceBuilder& sb) c
         mifi_atmosphere_hybrid_sigma_ap_pressure(shared, ps.values[loop[PS]], &ap.values[loop[AP]],
                 &b.values[loop[B]], &out_values[loop[OUT]]);
 
-        LOG4FIMEX(logger, Logger::DEBUG, "ps[" << loop[PS] << "]=" << ps.values[loop[PS]]
-                << " ap[" << loop[AP] << "]=" << ap.values[loop[AP]]
-                << " b[" << loop[B] << "]=" << b.values[loop[B]]
-                << " out[" << loop[OUT] << "]=" << out_values[loop[OUT]]);
+        // LOG4FIMEX(logger, Logger::DEBUG, "ps[" << loop[PS] << "]=" << ps.values[loop[PS]]
+        //         << " ap[" << loop[AP] << "]=" << ap.values[loop[AP]]
+        //         << " b[" << loop[B] << "]=" << b.values[loop[B]]
+        //         << " out[" << loop[OUT] << "]=" << out_values[loop[OUT]]);
     } while (loop.next());
     return createData(out_dims.volume(), out_values);
 }


### PR DESCRIPTION
Adding geopotential_height in model-layers to the output. Uses the existing PressureIntegrationToAltitudeConverter

solves #41 