### PR TITLE
basic support for lambert_lam

### DIFF
--- a/src/io/grib/GribFileIndex.cc
+++ b/src/io/grib/GribFileIndex.cc
@@ -636,7 +636,7 @@ GribFileMessage::GribFileMessage(grib_handle_p gh, const std::string& fileURL, l
     //        reduced_gg | sh | rotated_sh | stretched_sh | stretched_rotated_sh | space_view
     if (typeOfGrid_ == "regular_ll") {
         gridDefinition_ = getGridDefRegularLL(edition_, gh);
-    } else if (typeOfGrid_ == "lambert") {
+    } else if ((typeOfGrid_ == "lambert") || (typeOfGrid_ == "lambert_lam")) {
         gridDefinition_ = getGridDefLambert(edition_, gh);
     } else if (typeOfGrid_ == "mercator") {
         gridDefinition_ = getGridDefMercator(edition_, gh);


### PR DESCRIPTION
grib 2 [table 3.1] define

| Code | Meaning |
| ---- | :------ |
| 30   | Lambert conformal (Can be secant or tangent, conical or bipolar) |
| 33   | Lambert conformal with modelling subdomains definition|

where code 30 and 33 correspond to `gridType=lambert` and `gridType=lambert_lam`, respectively.

ecCodes define a template for `lambert_lam` ([template.3.33.def]) as an extension of the `lambert_lam` ([template.3.30.def]) as follows

```
# (C) Copyright 2005- ECMWF.

# TEMPLATE 3.33, Lambert conformal with modelling subdomains definition
include "grib2/templates/template.3.30.def"
include "grib2/templates/template.3.lam.def"
```

with [template.3.lam.def]

```
# modelling subdomains definition
unsigned[4] Nux  : dump;
alias numberOfUsefulPointsAlongXAxis  = Nux;

unsigned[4] Ncx  : dump;
alias numberOfPointsAlongXAxisInCouplingArea  = Ncx;

unsigned[4] Nuy  : dump;
alias numberOfUsefulPointsAlongYAxis  = Nuy;

unsigned[4] Ncy  : dump;
alias numberOfPointsAlongYAxisInCouplingArea  = Ncy;
```

As far as I can `Nux/Nuy` and `Ncx/Ncy` have no effect on the projection definition.
On the HARMONIE-AROME met files where I first encounter the `lambert_lam` grid,
as `Nux/Nuy` have the same values `Nx/Ny` (the standard `lambert` x/y-axis sizes).

[table 3.1]: https://codes.ecmwf.int/grib/format/grib2/ctables/3/1/
[template.3.33.def]: https://github.com/ecmwf/eccodes/blob/develop/definitions/grib2/templates/template.3.33.def
[template.3.30.def]: https://github.com/ecmwf/eccodes/blob/develop/definitions/grib2/templates/template.3.30.def
[template.3.lam.def]: https://github.com/ecmwf/eccodes/blob/develop/definitions/grib2/templates/template.3.lam.def
